### PR TITLE
Allow team min & max size to be specified in an "options" table in DB

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@
 
 # Ignore application configuration
 /config/application.yml
+TAGS

--- a/app/models/option.rb
+++ b/app/models/option.rb
@@ -1,0 +1,35 @@
+class Option < ActiveRecord::Base
+  before_create :confirm_singleton!
+  validates :minimum_team_size, :numericality =>
+    {:greater_than => 0, :only_integer => true}
+  validates :maximum_team_size, :numericality =>
+    {:greater_than => 0, :only_integer => true}
+  validate :max_team_size_greater_than_min
+
+  class IsSingletonError < RuntimeError;  end
+
+  private
+
+  def confirm_singleton!
+    raise Option::IsSingletonError.new("There can be only one set of options.") if
+      Option.count > 0
+  end
+
+  def max_team_size_greater_than_min
+    errors.add(:maximum_team_size, "cannot be less than minimum team size") if
+      maximum_team_size < minimum_team_size
+  end
+
+  public
+
+  # shortcut: make getters operate on the first (only) instance of model, eg
+  # Option.minimum_team_size instead of Option.first.minimum_team_size
+  def self.method_missing(name,*args,&block)
+    if Option.column_names.include?(name.to_s)
+      first.send(name,*args)
+    else
+      super
+    end
+  end
+
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -35,7 +35,7 @@ class Team < ActiveRecord::Base
     end
     
     def eligible?
-        self.users.count == 5 or self.users.count == 6 ? true : false
+        users.count.between?(Option.minimum_team_size, Option.maximum_team_size)
     end
     
     
@@ -59,6 +59,8 @@ class Team < ActiveRecord::Base
     end
     
     def can_join?
-        !(self.passcode.nil? or self.approved or self.users.size == 6)
+      ! passcode.nil?  &&
+        ! approved     &&
+        users.size < Option.maximum_team_size
     end
 end

--- a/db/migrate/20170417002226_add_singleton_option.rb
+++ b/db/migrate/20170417002226_add_singleton_option.rb
@@ -1,0 +1,8 @@
+class AddSingletonOption < ActiveRecord::Migration
+  def change
+    create_table :options, :force => true do |t|
+      t.integer :minimum_team_size
+      t.integer :maximum_team_size
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161124062115) do
+ActiveRecord::Schema.define(version: 20170417002226) do
 
   create_table "admins", force: :cascade do |t|
     t.string   "name"
@@ -30,6 +30,11 @@ ActiveRecord::Schema.define(version: 20161124062115) do
   end
 
   add_index "discussions", ["submission_id"], name: "index_discussions_on_submission_id"
+
+  create_table "options", force: :cascade do |t|
+    t.integer "minimum_team_size"
+    t.integer "maximum_team_size"
+  end
 
   create_table "submissions", force: :cascade do |t|
     t.integer  "disc1id"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,6 +10,15 @@ admins = [
       { :name => "Michael-David Sasson", :email => "sasson@berkeley.edu", :superadmin => false}
   ]
   
+Admin.delete_all
 admins.each do |a|
   Admin.create!(a)
 end
+
+Option.delete_all
+Option.create!(
+  :minimum_team_size => 3,
+  :maximum_team_size => 3
+  )
+
+  

--- a/features/emails/approved_teams.feature
+++ b/features/emails/approved_teams.feature
@@ -4,16 +4,13 @@ Feature: Email an admin information about approved teams
   I want to receive an email with all the teams that have been approved
   
   Background:
-    Given the following admins exist
-     | name | email                       |
-  	 | Bob  | enrollmeberkeley@gmail.com  |
-
+    Given the allowed team size is 5-6
     And I am on the login page
     And I log in as an admin with email "enrollmeberkeley@gmail.com"
 
   Scenario: Successfully create an account with my name and email
-    And I follow "Email Me"
-    And I should see "Welcome Back, Bob!"
+    When I follow "Email Me"
+    And I should see "Welcome Back, EnrollMe!"
     
   Scenario: Successfully emails an admin when they've been invited with a link to the site
     When I follow "Register New Admin"

--- a/features/step_definitions/enrollme_steps.rb
+++ b/features/step_definitions/enrollme_steps.rb
@@ -2,6 +2,16 @@ Given /^PENDING: .*$/ do
   pending
 end
 
+Given /^the allowed team size is (\d+)-(\d+)$/ do |min,max|
+  Option.first.update_attributes!(:minimum_team_size => min,
+    :maximum_team_size => max)
+end
+
+Given /^the allowed team size is (\d+)$/ do |num|
+  Option.first.update_attributes!(:minimum_team_size => num,
+    :maximum_team_size => num)
+end
+
 When /^I fill in "([^"]*)" with the correct password$/ do | field |
   fill_in(field, :with => ENV["ADMIN_DELETE_DATA_PASSWORD"])
 end

--- a/features/submissions/submit_team.feature
+++ b/features/submissions/submit_team.feature
@@ -5,14 +5,15 @@ Feature: student submits their team for approval
   I want to be able to choose discussions and submit my team for approval
   
   Background: users have been added to database
-  	Given the following users exist
-  		|   name    |       email                       | team      | major             |       sid         |  
-	    | Jorge     |    legueoflegends667@hotmail.com  | somepassc | Football Player   | 999               |
-	    | Bob0      |    bobjones0@berkeley.edu         | passcode1 | Slavic Studies    | 824               |
-	    | Bob1      |    bobjones1@berkeley.edu         | passcode1 | Slavic Studies    | 825               |
-	    | Bob2      |    bobjones2@berkeley.edu         | passcode1 | Slavic Studies    | 826               |
-	    | Bob3      |    bobjones3@berkeley.edu         | passcode1 | Slavic Studies    | 827               |
-      | Sahai     | eecs666@hotmail.com               | passcode1 | EECS              | 000       |
+    Given the allowed team size is 5-6
+    Given the following users exist
+        | name  | email                         | team      | major           | sid |
+        | Jorge | legueoflegends667@hotmail.com | somepassc | Football Player | 999 |
+        | Bob0  | bobjones0@berkeley.edu        | passcode1 | Slavic Studies  | 824 |
+        | Bob1  | bobjones1@berkeley.edu        | passcode1 | Slavic Studies  | 825 |
+        | Bob2  | bobjones2@berkeley.edu        | passcode1 | Slavic Studies  | 826 |
+        | Bob3  | bobjones3@berkeley.edu        | passcode1 | Slavic Studies  | 827 |
+        | Sahai | eecs666@hotmail.com           | passcode1 | EECS            | 000 |
     And I am on the login page
     
   Scenario: Submit button should not be present when team has only four members
@@ -23,10 +24,10 @@ Feature: student submits their team for approval
   Scenario: Submit button should be present when team has five or more members, and warning should be displayed
     Given I log in as a user with email "eecs666@hotmail.com"
     And the following discussions exist
-      | number  | time             | day        | capacity |
-   	  | 54321   | 3:00 PM          |  Tuesday   | 25       |
-   	  | 54322   | 3:00 PM          |  Wednesday | 25       |
-   	  | 54323   | 3:00 PM          | Thursday   | 25       |
+      | number | time    | day       | capacity |
+      |  54321 | 3:00 PM | Tuesday   |       25 |
+      |  54322 | 3:00 PM | Wednesday |       25 |
+      |  54323 | 3:00 PM | Thursday  |       25 |
    	And I am on the team "2" page
     Then I should see the "Submit" button
     And I should see "Warning: You need to submit your team"
@@ -34,10 +35,10 @@ Feature: student submits their team for approval
   Scenario: Successfully choose discussions and submit team for approval
     Given I log in as a user with email "eecs666@hotmail.com"
     And the following discussions exist
-      | number  | time             | day        | capacity |
-   	  | 54321   | 3:00 PM          |  Tuesday   | 25       |
-   	  | 54322   | 3:00 PM          |  Wednesday | 25       |
-   	  | 54323   | 3:00 PM          | Thursday   | 25       |
+      | number | time    | day       | capacity |
+      |  54321 | 3:00 PM | Tuesday   |       25 |
+      |  54322 | 3:00 PM | Wednesday |       25 |
+      |  54323 | 3:00 PM | Thursday  |       25 |
    	And I am on the team "2" page
    	When I press "Submit"
     And I select "CCN: 54321 | Time: Tuesday 3:00 PM | Enrolled: 0 / 25" from "submission[disc1id]"
@@ -54,9 +55,9 @@ Feature: student submits their team for approval
   Scenario: There is exactly one discussion that can take a user's team
     Given I log in as a user with email "eecs666@hotmail.com"
     And the following discussions exist
-      | number  | time             | day        | capacity |
-   	  | 54321   | 3:00 PM          |  Tuesday   | 25       |
-   	And I am on the team "2" page
+      | number | time    | day     | capacity |
+      |  54321 | 3:00 PM | Tuesday |       25 |
+    And I am on the team "2" page
     When I press "Submit"
     And I select "CCN: 54321 | Time: Tuesday 3:00 PM | Enrolled: 0 / 25" from "submission[disc1id]"
     When I press "Submit"
@@ -66,14 +67,15 @@ Feature: student submits their team for approval
   Scenario: User cannot choose two of the same discussion
     Given I log in as a user with email "eecs666@hotmail.com"
     And the following discussions exist
-      | number  | time             | day        | capacity |
-   	  | 54321   | 3:00 PM          |  Tuesday   | 25       |
-   	  | 54322   | 3:00 PM          |  Wednesday   | 25       |
-   	  | 54323   | 3:00 PM          |  Thursday   | 25       |
-   	And I am on the team "2" page
+      | number | time    | day       | capacity |
+      |  54321 | 3:00 PM | Tuesday   |       25 |
+      |  54322 | 3:00 PM | Wednesday |       25 |
+      |  54323 | 3:00 PM | Thursday  |       25 |
+    And I am on the team "2" page
     When I press "Submit"
     And I select "CCN: 54321 | Time: Tuesday 3:00 PM | Enrolled: 0 / 25" from "submission[disc1id]"
     And I select "CCN: 54321 | Time: Tuesday 3:00 PM | Enrolled: 0 / 25" from "submission[disc2id]"
     And I select "CCN: 54321 | Time: Tuesday 3:00 PM | Enrolled: 0 / 25" from "submission[disc3id]"
     And I press "Submit"
     Then I should see "Please choose 3 different discussions"
+    

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -63,6 +63,11 @@ end
 #   end
 #
 
+# Load seeds file before each scenario
+Before do
+  load 'db/seeds.rb'
+end
+
 # Possible values are :truncation and :transaction
 # The :transaction strategy is faster, but might give you threading problems.
 # See https://github.com/cucumber/cucumber-rails/blob/master/features/choose_javascript_database_strategy.feature

--- a/features/team_editing/user_edits_submitted_team.feature
+++ b/features/team_editing/user_edits_submitted_team.feature
@@ -5,7 +5,8 @@ Feature: editing a team changes its submission status
   I want to modify my team submission before it gets approved
   
   Background:
-    Given the following users exist
+    Given the allowed team size is 5-6
+    And   the following users exist
      | name  |       email                    |team_passcode | major           | sid  |
      | Sahai | eecs666@hotmail.com            | penguindrool | EECS            | 000  |
      | Saha2 | eecs667@hotmail.com            | penguindrool | EECS            | 001  |

--- a/features/users/without_team_page.feature
+++ b/features/users/without_team_page.feature
@@ -5,14 +5,15 @@ Feature: join or create a team
   I want to be able to join or create a team
   
   Background:
-    Given the following users exist
-     |   name    |       email       |team_passcode | major        |       sid      |
-  	 | Jorge    |    legueoflegends667@hotmail.com  | 0 | Football Player | 999  |
- 	   | Sahai     | eecs666@hotmail.com        | penguindrool | EECS            | 000  |
- 	   | Saha1     | eecs667@hotmail.com        | penguindrool | EECS            | 001  |
- 	   | Saha2     | eecs668@hotmail.com        | penguindrool | EECS            | 002  |
- 	   | Saha3     | eecs669@hotmail.com        | penguindrool | EECS            | 003  |
- 	   | Saha4     | eecs660@hotmail.com        | penguindrool | EECS            | 004  |
+    Given the allowed team size is 5-6
+    And   the following users exist
+     | name  | email                         | team_passcode | major           | sid |
+     | Jorge | legueoflegends667@hotmail.com | 0             | Football Player | 999 |
+     | Sahai | eecs666@hotmail.com           | penguindrool  | EECS            | 000 |
+     | Saha1 | eecs667@hotmail.com           | penguindrool  | EECS            | 001 |
+     | Saha2 | eecs668@hotmail.com           | penguindrool  | EECS            | 002 |
+     | Saha3 | eecs669@hotmail.com           | penguindrool  | EECS            | 003 |
+     | Saha4 | eecs660@hotmail.com           | penguindrool  | EECS            | 004 |
 
     And I am on the login page
     And I log in as a user with email "legueoflegends667@hotmail.com"

--- a/spec/models/option_spec.rb
+++ b/spec/models/option_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+describe Option do
+  it 'is seeded with options' do
+    expect(Option.first).to be_a_kind_of Option
+  end
+  it 'is an error to create another' do
+    expect { Option.create(:minimum_team_size => 1, :maximum_team_size => 3) }.
+      to raise_error(Option::IsSingletonError)
+  end
+  it 'allows using class methods to dereference singleton attributes' do
+    expect(Option.minimum_team_size).to be_a_kind_of Integer
+  end
+  it 'requires max team size no less than min' do
+    (o = Option.first).update_attributes(:minimum_team_size => 3,:maximum_team_size => 2)
+    expect(o.errors.full_messages).to include("Maximum team size cannot be less than minimum team size")
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -51,7 +51,12 @@ RSpec.configure do |config|
   # the seed, which is printed after each run.
   #     --seed 1234
   config.order = "random"
-  
+
+  # Load seeds before all specs
+  config.before(:each) do
+    load 'db/seeds.rb'
+  end
 end
 
 OmniAuth.config.test_mode = true
+


### PR DESCRIPTION
New 'options' table sets min/max team size, and in future can set other variable features here, although currently no UI to edit it (i.e. must set the values using command line). `db/seeds.rb` specifies initial values for options. Team validation code, specs, and features updated to use this functionality.